### PR TITLE
Fix macOS compiling erros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(VERSION_INFO_MAINT_VERSION 0)
 # Flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_MACOSX_RPATH 1)
 
 # Includes
 include_directories ("${PROJECT_SOURCE_DIR}/includes")

--- a/includes/SatHelper/tools.h
+++ b/includes/SatHelper/tools.h
@@ -32,7 +32,7 @@ namespace SatHelper {
         }
 
         inline static void makedir(const std::string &folder) {
-            #ifdef __linux__
+            #if defined(__linux__) || defined(__APPLE__)
             mkdir(folder.c_str(), 0777);
             #else
             _mkdir(folder.c_str());

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -18,9 +18,6 @@
     #ifndef MSG_WAITALL
         #define MSG_WAITALL (1 << 3)
     #endif
-    #ifndef MSG_NOSIGNAL
-        #define MSG_NOSIGNAL 0
-    #endif
 #else
     #include <sys/socket.h>
     #include <arpa/inet.h>
@@ -30,6 +27,11 @@
     #include <netdb.h>
     #include <unistd.h>
     #define ioctlsocket ioctl
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+    #ifndef MSG_NOSIGNAL
+        #define MSG_NOSIGNAL 0
+    #endif
 #endif
 using namespace SatHelper;
 
@@ -156,4 +158,3 @@ void Socket::Close() {
 #endif
     }
 }
-


### PR DESCRIPTION
Now fully compatible with macOS.

- Add CMakeLists CMAKE_MACOSX_RPATH flag.
- Update definitions for Linux & macOS.

![screenshot 2017-01-26 16 48 53](https://cloud.githubusercontent.com/assets/6627901/22346049/a564e140-e3e9-11e6-9f8c-d3a63f536493.png)
 