### PR TITLE
Fix compilation error by adding subdirectory to location of extension…

### DIFF
--- a/includes/SatHelper/viterbi27.h
+++ b/includes/SatHelper/viterbi27.h
@@ -9,7 +9,7 @@
 #define SATHELPER_INCLUDES_VITERBI27_H_
 
 #include <cstdint>
-#include <extensions.h>
+#include <SatHelper/extensions.h>
 
 namespace SatHelper {
 #define _VITERBI27_POLYA 0x4F


### PR DESCRIPTION
xrit{decode,demod} fail compilation when using libSatHelper/BenchmarkTests branch.